### PR TITLE
feat(bootstrap): add decorate mode for existing repositories

### DIFF
--- a/tgs/612a57f-decorate-existing-software-project-repository/README.md
+++ b/tgs/612a57f-decorate-existing-software-project-repository/README.md
@@ -1,0 +1,12 @@
+## Sample Thought Directory (TGS Template)
+
+Use this as a template when creating a new thought under `tgs/<BASE_HASH>-<kebab-title>/`.
+
+### Files
+- `research.md` — problem analysis, options, and recommended approach.
+- `plan.md` — objectives, scope, acceptance criteria, phased steps, test/rollout.
+- `implementation.md` — summary of changes, how to test, integration, rollback.
+
+See `tgs/7f5d32a-macos-dev-tools-security-overhaul/` for a real example.
+
+

--- a/tgs/612a57f-decorate-existing-software-project-repository/implementation.md
+++ b/tgs/612a57f-decorate-existing-software-project-repository/implementation.md
@@ -1,0 +1,59 @@
+# Implementation Summary: Decorate Existing Software Project Repository
+
+## 1. Overview (What & Why)
+Add a non-interactive decorate mode to `bootstrap.sh` that injects only the minimal TGS workflow files into an existing repository, avoiding templates and repo-level README by default, and without creating a subdirectory or initializing a new git repository. Includes `--dry-run`, `--force`, and optional `--with-templates` overlay.
+
+## 2. File Changes
+- Edited: `bootstrap.sh`
+  - Bump `SCRIPT_VERSION` to `1.2.0`
+  - Add flags: `--decorate`, `--dry-run`, `--force`, `--with-templates=<type>`
+  - Implement decorate flow: copy `agentops/AGENTOPS.md`, `tgs/README.md`, `agentops/tgs/*`; generate `tgs.mk`; ensure `Makefile` includes it
+  - Safe copy helpers, idempotent behavior, and logs
+  - Detect existing `.git` and, when not explicitly decorating, prompt the user to choose: decorate current repo, create a new project, or quit (respects `--dry-run` messaging)
+  - Keep existing bootstrap behavior unchanged by default
+
+## 3. Commands & Migrations
+No migrations. New runtime-generated file `tgs.mk` provides `new-thought` target when included.
+
+## 4. How to Test
+- Dry run (no changes):
+  ```bash
+  ./bootstrap.sh --decorate --dry-run
+  ```
+- Apply minimal workflow into current directory:
+  ```bash
+  ./bootstrap.sh --decorate
+  ```
+- Force overwrite existing files if needed:
+  ```bash
+  ./bootstrap.sh --decorate --force
+  ```
+- Optional template overlay (e.g., react):
+  ```bash
+  ./bootstrap.sh --decorate --with-templates=react
+  ```
+
+- Run without `--decorate` inside an existing git repository to see the prompt:
+  ```bash
+  ./bootstrap.sh
+  # Expect a prompt: decorate current repo (d), new project (n), or quit (q)
+  ```
+
+Expected after decorate (no template):
+- `agentops/AGENTOPS.md`, `tgs/README.md`, and `agentops/tgs/*` present
+- `tgs.mk` created; `Makefile` includes `tgs.mk` (or minimal `Makefile` created)
+- Existing files not overwritten unless `--force`
+
+## 5. Integration Steps
+- Commit added files and include `tgs.mk` in your `Makefile` if not already.
+- Use `make new-thought title="Your idea"` to create thought directories.
+
+## 6. Rollback
+- Remove generated files: `agentops/AGENTOPS.md`, `tgs/README.md`, `agentops/tgs/*` (if newly added), `tgs.mk`, and the `include tgs.mk` line from `Makefile`.
+
+## 7. Follow-ups & Next Steps
+- Consider `--only`/`--exclude` patterns for advanced control.
+- Add CI smoke test for `--decorate --dry-run` path.
+
+## 8. Links
+- Thought: `tgs/612a57f-decorate-existing-software-project-repository/`

--- a/tgs/612a57f-decorate-existing-software-project-repository/plan.md
+++ b/tgs/612a57f-decorate-existing-software-project-repository/plan.md
@@ -1,0 +1,82 @@
+# Plan: Decorate Existing Software Project Repository
+
+## 1. Objectives
+- Provide a safe, idempotent "decorate" mode in `bootstrap.sh` to adopt TGSFlow in an existing repository.
+- Copy only the essential TGS workflow files; avoid templates and TGSFlow repo `README.md` by default.
+- Do not create a subdirectory or initialize a git repo; operate in the current working directory.
+- Add `--dry-run` and `--force` flags for visibility and control.
+
+## 2. Scope / Non-goals
+In-scope:
+- Extend `bootstrap.sh` with `--decorate`, `--dry-run`, `--force`, and optional `--with-templates=<type>`.
+- Logic to copy minimal files and wire up a `new-thought` make target via a new `tgs.mk` include file.
+- Update thought docs (`implementation.md`) with how to test and integrate.
+
+Out-of-scope:
+- Changing existing project templates (react/python/go/cli).
+- Overhauling repo docs beyond decorate flow.
+- Building a separate distribution artifact; we keep a single script.
+
+## 3. Acceptance Criteria
+- `./bootstrap.sh --decorate` runs non-interactively and does NOT prompt for template or project name.
+- No new subdirectory is created; no `git init` is executed in decorate mode.
+- By default, the following are copied into the current directory (creating parent dirs as needed):
+  - `agentops/AGENTOPS.md`
+  - `tgs/README.md`
+  - `agentops/tgs/*` (file templates for thoughts)
+  - `tgs.mk` generated with a `new-thought` target equivalent to the root Makefile's implementation
+- Existing files are not overwritten unless `--force` is provided; skipped files are logged.
+- If `Makefile` exists and does not already include `tgs.mk` or define `new-thought`, append a single line `include tgs.mk` (idempotent).
+- If `Makefile` does not exist, create a minimal one containing `include tgs.mk` and a `help` target that lists `new-thought`.
+- The TGSFlow repo `README.md` at root and the `templates/` directory are NOT copied by default.
+- `--with-templates=<react|python|go|cli|none>` is supported; default `none`. When set to a template type, files from `templates/<type>/` are copied into the current directory with the same non-destructive semantics.
+- `--dry-run` prints all intended actions without writing any files. Works for both decorate and existing bootstrap paths.
+- Script version bumped to `1.2.0`; help text updated to document new flags.
+
+## 4. Phases & Tasks
+- Phase 1: Design & Flags
+  - [x] Define flags and behavior in research/plan
+  - [ ] Update help/usage output in script
+- Phase 2: Implement Decorate Mode
+  - [ ] Add argument parsing and mode dispatch
+  - [ ] Implement safe copy functions with `--dry-run` and `--force`
+  - [ ] Generate `tgs.mk` and wire `Makefile` include/idempotency
+  - [ ] Optional template overlay via `--with-templates`
+- Phase 3: Testing & Docs
+  - [ ] Manual tests across scenarios (with/without Makefile, with `--force`, idempotency)
+  - [ ] Update `tgs/612a57f.../implementation.md` with summary and test steps
+
+## 5. File/Module Changes
+- Edit: `bootstrap.sh`
+  - Add `--decorate`, `--dry-run`, `--force`, `--with-templates` flags
+  - Add decorate execution path; no prompts; no subdir; no git init
+  - Implement safe copy helpers and logging; bump `SCRIPT_VERSION` to `1.2.0`
+- Add (generated at runtime by script, not committed): `tgs.mk`
+  - Contains `new-thought` target copied from current `Makefile` logic
+- Edit: `tgs/612a57f.../implementation.md` (docs)
+
+## 6. Test Plan
+Manual checks:
+1) In a temp dir with no git:
+   - Run: `curl -sSL https://raw.githubusercontent.com/akelv/tgsflow/main/bootstrap.sh | bash -s -- --decorate --dry-run`
+   - Expect: Logs of intended copies; no files written.
+   - Run without `--dry-run`: files `agentops/AGENTOPS.md`, `tgs/README.md`, `agentops/tgs/*`, `tgs.mk`, and a minimal `Makefile` created.
+   - Re-run: no changes reported; idempotent.
+2) In a repo with existing `Makefile` lacking `new-thought`:
+   - Run decorate; expect `include tgs.mk` appended once.
+3) With `--with-templates=none` (default): no app template files copied.
+4) With `--with-templates=react` in an empty dir: files from `templates/react/` overlayed; existing files preserved unless `--force`.
+5) With existing `README.md`: ensure root `README.md` from tgsflow is not copied or modified.
+
+## 7. Rollout & Rollback
+- Rollout: merge PR; users can immediately run with new flags.
+- Rollback: revert PR; existing installs remain unaffected.
+
+## 8. Estimates & Risks
+- Estimate: 2-3 hours including testing and docs.
+- Risks: accidental overwrites (mitigated by default skip + `--force`), path edge-cases on different shells (covered by guarded bash, minimal dependencies).
+
+---
+Approval checkpoint: Please review this plan and reply one of:
+- APPROVE plan
+- REQUEST CHANGES: <notes>

--- a/tgs/612a57f-decorate-existing-software-project-repository/research.md
+++ b/tgs/612a57f-decorate-existing-software-project-repository/research.md
@@ -1,0 +1,71 @@
+# Research: Decorate Existing Software Project Repository
+
+- Date: 2025-09-11
+- Base Hash: TBD at PR time
+- Participants: AI Agent (proposer), Human Maintainer (approver)
+
+## 1. Problem Statement
+Engineers with an existing repository want to adopt the TGSFlow workflow without scaffolding a new project or bringing in all templates and repo-level docs from `tgsflow`. The current `bootstrap.sh` always clones the full repo into a new subdirectory, applies a template, copies the root `README.md`, and initializes a new git repository. This behavior is unsuitable for decorating an existing codebase where only the minimal TGS workflow files are desired and no subdirectory should be created.
+
+Desired outcome: a safe "decorate" mode that injects the essential TGS workflow into the current repository without creating a new directory, avoiding template payloads by default, not overwriting project `README.md`, and providing a dry-run for visibility.
+
+## 2. Current State
+- `bootstrap.sh` (v1.1.1) flow:
+  - Prompts for template and project name.
+  - Clones `tgsflow` to a temp dir, then copies everything into `<project_name>/`.
+  - Applies selected template from `templates/<type>` into that directory.
+  - Updates `README.md` contents, initializes a fresh git repo and commits.
+- Minimal TGS workflow components today:
+  - `agentops/AGENTOPS.md` (system prompt + workflow guide)
+  - `tgs/README.md` (thoughts directory guide)
+  - `agentops/tgs/*` (file templates for `make new-thought`)
+  - `Makefile` provides `new-thought` target relying on `agentops/tgs/*` existing
+
+Issues for existing repos:
+- Creates an extra subdirectory; undesired.
+- Pulls in templates and TGSFlow repo `README.md` by default; noisy/irrelevant.
+- Initializes git history in a subfolder; conflicts with existing repos.
+
+## 3. Constraints & Assumptions
+- Must be safe and non-destructive by default; do not overwrite existing files unless `--force` is specified.
+- No additional dependencies beyond `git` and `curl`.
+- Should be non-interactive for decorate mode; no prompts for project type/name.
+- Idempotent: running decorate multiple times should be safe.
+- Cross-platform shell considerations: POSIX-friendly bash; avoid GNU-only utilities where feasible.
+
+## 4. Risks & Impact
+- Overwriting `README.md` or `Makefile` in existing repos (mitigated by default skip and `--force`).
+- Partial adoption if essential files are omitted (ensure we copy the minimal set reliably).
+- Confusion around templates; default to none and require explicit opt-in.
+
+## 5. Alternatives Considered
+1) Separate script (e.g., `decorate.sh`): clearer separation but duplicates logic and increases maintenance.
+2) Separate branch/tarball containing only minimal TGS files: simple distribution, but diverges from main and risks drift.
+3) Enhance `bootstrap.sh` with `--decorate` mode: single entry-point, consistent UX, minimal maintenance.
+
+Chosen: Enhance `bootstrap.sh` with `--decorate`.
+
+## 6. Recommendation
+Add `--decorate` mode to `bootstrap.sh` with these properties:
+- Operates in the current directory; no project directory creation; no git init.
+- Copies only essential files by default:
+  - `agentops/AGENTOPS.md`
+  - `tgs/README.md`
+  - `agentops/tgs/*`
+  - A small `tgs.mk` make include containing the `new-thought` target. If a `Makefile` exists, append `include tgs.mk` if absent; otherwise, create a minimal `Makefile` that includes `tgs.mk`.
+- Never copy repo-level `README.md` from `tgsflow` and do not copy `templates/` unless explicitly requested.
+- Flags:
+  - `--decorate`: enable decorate mode
+  - `--dry-run`: print planned operations without writing
+  - `--force`: allow overwrites when necessary
+  - `--with-templates=<react|python|go|cli|none>`: optional; default `none`
+- Be idempotent and produce clear logs.
+
+## 7. References & Links
+- Current `bootstrap.sh` behavior and structure
+- `agentops/AGENTOPS.md`, `tgs/README.md`, `agentops/tgs/*`
+
+---
+Approval checkpoint: Please review this research and reply one of:
+- APPROVE research
+- REQUEST CHANGES: <notes>

--- a/tgs/README.md
+++ b/tgs/README.md
@@ -34,7 +34,7 @@ This organizational structure provides:
 
 ## Usage
 
-When starting a new thought/improvement:
+When starting a new thought/improvement in a decorated or bootstrapped repo:
 
 1. Get the current git HEAD hash: `git rev-parse --short HEAD`
 2. Create directory: `tgs/<hash>-<short-description>/`
@@ -49,6 +49,26 @@ Or use the helper:
 ```bash
 make new-thought title="Your idea here"
 ```
+
+## Bootstrapping vs Decorating
+
+- Use bootstrap for greenfield projects: 
+  ```bash
+  curl -sSL https://raw.githubusercontent.com/akelv/tgsflow/main/bootstrap.sh | bash
+  ```
+  Follow prompts to select a template and project name.
+
+- Use decorate for existing repositories (adds only the TGS workflow files to the current repo):
+  ```bash
+  curl -sSL https://raw.githubusercontent.com/akelv/tgsflow/main/bootstrap.sh | bash -s -- --decorate
+  ```
+
+Behavior:
+- If you run `bootstrap.sh` in a directory that already contains a `.git` folder without `--decorate`, the script will prompt you to choose:
+  - Decorate the current repository (recommended to adopt TGS in-place), or
+  - Initialize a new project in a subdirectory, or
+  - Quit.
+- `--dry-run` is supported to preview changes.
 
 ## TGSFlow Workflow
 


### PR DESCRIPTION
- Add --decorate, --dry-run, --force, --with-templates flags
- Non-destructive decorate flow copies minimal TGS workflow (agentops/AGENTOPS.md, tgs/README.md, agentops/tgs/*)
- Generate tgs.mk and ensure Makefile includes it idempotently
- Detect existing .git when not decorating and prompt for decorate/new/quit
- Keep existing bootstrap flow untouched by default

Docs:
- Update tgs/README.md with Bootstrapping vs Decorating and prompt behavior
- Implementation details in tgs/612a57f-decorate-existing-software-project-repository/implementation.md

Thought: tgs/612a57f-decorate-existing-software-project-repository/